### PR TITLE
feat: pass auth params to OnConnection callback

### DIFF
--- a/connection_event.go
+++ b/connection_event.go
@@ -4,7 +4,7 @@ import (
 	"sync"
 )
 
-type connectionEventCallback func(payload *Socket)
+type connectionEventCallback func(payload *Socket, paramsRow map[string]string)
 
 type connectionEvent struct {
 	sync.RWMutex

--- a/example/main.go
+++ b/example/main.go
@@ -20,7 +20,14 @@ func socketIoHandle(io *socketio.Io) {
 		return true
 	})
 
-	io.OnConnection(func(socket *socketio.Socket) {
+	io.OnConnection(func(socket *socketio.Socket, params map[string]string) {
+		// Get chatID from auth params
+		// chatIDStr, ok := params["chatID"]
+		// if !ok || len(chatIDStr) == 0 {
+		// 	socket.Emit("error", "Missing chatID")
+		// 	return
+		// }
+
 		println("connect", socket.Nps, socket.Id)
 		socket.Join("demo")
 		io.To("demo").Emit("test", socket.Id+" join us room...", "server message")
@@ -74,7 +81,7 @@ func socketIoHandle(io *socketio.Io) {
 		})
 	})
 
-	io.Of("/test").OnConnection(func(socket *socketio.Socket) {
+	io.Of("/test").OnConnection(func(socket *socketio.Socket, params map[string]string) {
 		println("connect", socket.Nps, socket.Id)
 
 		socket.On("chat message", func(event *socketio.EventPayload) {

--- a/server.go
+++ b/server.go
@@ -376,7 +376,9 @@ func (s *Io) new() func(ctx *fiber.Ctx) error {
 						}.ToJson())
 
 						for _, callback := range s.Of(namespace).onConnection.get("connection") {
-							callback(socket_nps)
+							dataJson := map[string]string{}
+							json.Unmarshal([]byte(rawpayload), &dataJson)
+							callback(socket_nps, dataJson)
 						}
 					case socket_protocol.EVENT.String():
 						socket_nps, err := s.Of(namespace).sockets.get(socket.Id)
@@ -575,7 +577,9 @@ func (s *Io) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					}.ToJson())
 
 					for _, callback := range s.Of(namespace).onConnection.get("connection") {
-						callback(socket_nps)
+						dataJson := map[string]string{}
+						json.Unmarshal([]byte(rawpayload), &dataJson)
+						callback(socket_nps, dataJson)
 					}
 				case socket_protocol.EVENT.String():
 					socket_nps, err := s.Of(namespace).sockets.get(socket.Id)


### PR DESCRIPTION
- Modified OnConnection to provide auth params (map[string]string) to the callback function.
- This allows developers to access connection parameters directly within OnConnection, enabling use cases like querying data or custom logic based on params.
- Maintains separation of concerns: OnAuthorization remains available for dedicated auth validation, while OnConnection can now access params for additional context.