### PR TITLE
Smoll QoL additions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/gofiber/websocket/v2 v2.2.1
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/websocket v1.5.3
+	github.com/stretchr/testify v1.9.0
 )
 
 require (
@@ -17,6 +18,7 @@ require (
 	github.com/bytedance/sonic/loader v0.2.1 // indirect
 	github.com/cloudwego/base64x v0.1.4 // indirect
 	github.com/cloudwego/iasm v0.2.0 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/fasthttp/websocket v1.5.3 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.7 // indirect
 	github.com/gin-contrib/sse v0.1.0 // indirect
@@ -35,6 +37,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.3 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rivo/uniseg v0.2.0 // indirect
 	github.com/savsgio/gotils v0.0.0-20230208104028-c358bd845dee // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-github.com/andybalholm/brotli v1.0.5 h1:8uQZIdzKmjc/iuPu7O2ioW48L81FgatrcpfFmiq/cCs=
-github.com/andybalholm/brotli v1.0.5/go.mod h1:fO7iG3H7G2nSZ7m0zPUDn85XEX2GTukHGRSepvi9Eig=
 github.com/andybalholm/brotli v1.1.0 h1:eLKJA0d02Lf0mVpIDgYnqXcUn0GqVmEFny3VuID1U3M=
 github.com/andybalholm/brotli v1.1.0/go.mod h1:sms7XGricyQI9K10gOSf56VKKWS4oLer58Q+mhRPtnY=
 github.com/bytedance/sonic v1.12.6 h1:/isNmCUF2x3Sh8RAp/4mh4ZGkcFAX/hLrzrK3AvpRzk=
@@ -35,8 +33,6 @@ github.com/go-playground/validator/v10 v10.23.0 h1:/PwmTwZhS0dPkav3cdK9kV1FsAmrL
 github.com/go-playground/validator/v10 v10.23.0/go.mod h1:dbuPbCMFw/DrkbEynArYaCwl3amGuJotoKCe95atGMM=
 github.com/goccy/go-json v0.10.4 h1:JSwxQzIqKfmFX1swYPpUThQZp/Ka4wzJdK0LWVytLPM=
 github.com/goccy/go-json v0.10.4/go.mod h1:oq7eo15ShAhp70Anwd5lgX2pLfOS3QCiwU/PULtXL6M=
-github.com/gofiber/fiber/v2 v2.52.5 h1:tWoP1MJQjGEe4GB5TUGOi7P2E0ZMMRx5ZTG4rT+yGMo=
-github.com/gofiber/fiber/v2 v2.52.5/go.mod h1:KEOE+cXMhXG0zHc9d8+E38hoX+ZN7bhOtgeF2oT6jrQ=
 github.com/gofiber/fiber/v2 v2.52.9 h1:YjKl5DOiyP3j0mO61u3NTmK7or8GzzWzCFzkboyP5cw=
 github.com/gofiber/fiber/v2 v2.52.9/go.mod h1:YEcBbO/FB+5M1IZNBP9FO3J9281zgPAreiI1oqg8nDw=
 github.com/gofiber/websocket/v2 v2.2.1 h1:C9cjxvloojayOp9AovmpQrk8VqvVnT8Oao3+IUygH7w=
@@ -50,8 +46,6 @@ github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aN
 github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
-github.com/klauspost/compress v1.17.0 h1:Rnbp4K9EjcDuVuHtd0dgA4qNuv9yKDYKK1ulpJwgrqM=
-github.com/klauspost/compress v1.17.0/go.mod h1:ntbaceVETuRiXiv4DpjP66DpAtAGkEQskQzEyD//IeE=
 github.com/klauspost/compress v1.17.9 h1:6KIumPrER1LHsvBVuDa0r5xaG0Es51mhhB9BQB2qeMA=
 github.com/klauspost/compress v1.17.9/go.mod h1:Di0epgTjJY877eYKx5yC51cX2A2Vl2ibi7bDH9ttBbw=
 github.com/klauspost/cpuid/v2 v2.0.9/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=
@@ -69,8 +63,6 @@ github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovk
 github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
-github.com/mattn/go-runewidth v0.0.15 h1:UNAjwbU9l54TA3KzvqLGxwWjHmMgBUVhBiTjelZgg3U=
-github.com/mattn/go-runewidth v0.0.15/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
 github.com/mattn/go-runewidth v0.0.16 h1:E5ScNMtiwvlvB5paMFdw9p4kSQzbXFikJ5SQO6TULQc=
 github.com/mattn/go-runewidth v0.0.16/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=

--- a/server.go
+++ b/server.go
@@ -110,7 +110,6 @@ func (s *Io) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	header := r.Header
 	if slices.Contains(header["Connection"], "Upgrade") && header.Get("Upgrade") == "websocket" {
-		// if true {
 		log.Println("conection:upgrade")
 
 		upgrader.CheckOrigin = func(r *http.Request) bool { return true }
@@ -121,19 +120,13 @@ func (s *Io) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 		defer c.Close()
 
-		// var id string
-
 		if r.URL.Query()["sid"] != nil {
-			log.Print("sid presented ! ")
-
 			return
-			// Still allows it ?
 		}
-		// log.Println("SID:", id)
 
 		socket := Socket{
 			Id:  s.randomUUID(),
-			Nps: "/",
+			Nsp: "/",
 			Conn: &Conn{
 				http:       c,
 				reqHeaders: r.Header.Clone(),
@@ -147,11 +140,7 @@ func (s *Io) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			pingTime: s.pingInterval,
 		}
 
-		defer func() {
-			log.Printf("socket %q closed", socket.Id)
-
-			socket.disconnect()
-		}()
+		defer socket.disconnect()
 
 		socket.dispose = append(socket.dispose, func() {
 			s.sockets.delete(socket.Id)
@@ -166,36 +155,29 @@ func (s *Io) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			Upgrades:     []string{"websocket"},
 		}.ToJson())
 
-		log.Printf("headers %q: %+v", socket.Id, socket.Conn.reqHeaders)
-		log.Printf("query %q: %+v", socket.Id, socket.Conn.reqQuery)
-
 		for {
+
 			messageType, message, err := c.ReadMessage()
 			if err != nil {
-				log.Printf("got error: %v\n", err)
+				log.Printf("[socket.io] input error: %v\n", err)
+
 				break
 			}
 
 			if messageType == websocket.TextMessage {
 				err := s.handlerMessage(&socket, string(message))
 				if err != nil {
-					log.Printf("got error: %v\n", err)
+					log.Printf("[socket.io] message handling error: %v\n", err)
 
 					return
 				}
 			}
 		}
 	} else if strings.HasPrefix(r.URL.Path, s.path) {
-
-		log.Println("conection:path match")
-
 		clientDistFs, _ := fs.Sub(staticFS, "client-dist")
 		fs := http.StripPrefix(s.path, http.FileServer(http.FS(clientDistFs)))
 		fs.ServeHTTP(w, r)
 	} else {
-
-		log.Printf("conection:not found: got [%q] want [%q]", r.URL.Path, s.path)
-
 		http.NotFound(w, r)
 	}
 }
@@ -338,7 +320,7 @@ func (s *Io) new() func(ctx *fiber.Ctx) error {
 
 		socket := Socket{
 			Id:  s.randomUUID(),
-			Nps: "/",
+			Nsp: "/",
 			Conn: &Conn{
 				fasthttp: c,
 			},
@@ -380,9 +362,14 @@ func (s *Io) new() func(ctx *fiber.Ctx) error {
 }
 
 func (s *Io) handlerMessage(socket *Socket, message string) error {
+	log.Printf("[socket.io] recv packet sid=%s ns=%s  data=%s\n",
+		socket.Id, socket.Nsp, message)
+
 	enginePacketType := string(message[0:1])
 	switch enginePacketType {
 	case engineio.MESSAGE.String():
+		// log.Println("[socket.io] string message")
+
 		mess := string(message)
 		packetType := string(message[1:2])
 		rawpayload := string(message[2:])
@@ -436,6 +423,8 @@ func (s *Io) handlerMessage(socket *Socket, message string) error {
 
 		switch packetType {
 		case socket_protocol.DISCONNECT.String():
+			// log.Println("[socket.io] disconnect message")
+
 			socket_nps, err := s.Of(namespace).sockets.get(socket.Id)
 			if err != nil {
 				return err
@@ -450,11 +439,13 @@ func (s *Io) handlerMessage(socket *Socket, message string) error {
 				})
 			}
 		case socket_protocol.CONNECT.String():
+			// log.Println("[socket.io] connect message")
+
 			socket_nps := socket
 			if namespace != "/" {
 				socketWithNamespace := Socket{
 					Id:   socket.Id,
-					Nps:  namespace,
+					Nsp:  namespace,
 					Conn: socket.Conn,
 					listeners: listeners{
 						list: make(map[string][]eventCallback),
@@ -473,6 +464,8 @@ func (s *Io) handlerMessage(socket *Socket, message string) error {
 			}
 
 			if s.onAuthentication != nil {
+				// log.Printf("[socket.io] connect with auth")
+
 				dataJson := map[string]string{}
 				json.Unmarshal([]byte(rawpayload), &dataJson)
 				if !s.onAuthentication(dataJson) {
@@ -515,6 +508,7 @@ func (s *Io) handlerMessage(socket *Socket, message string) error {
 			for _, callback := range s.Of(namespace).onConnection.get("connection") {
 				callback(socket_nps)
 			}
+
 		case socket_protocol.EVENT.String():
 			socket_nps, err := s.Of(namespace).sockets.get(socket.Id)
 			if err != nil {
@@ -543,7 +537,9 @@ func (s *Io) handlerMessage(socket *Socket, message string) error {
 			// case socket_protocol.BINARY_ACK.String():
 		}
 	case engineio.PONG.String():
-		// println("Client pong")
+		// println("[socket.io] client pong")
+	default:
+		log.Println("[socket.io] un-handled message")
 	}
 	return nil
 }

--- a/server.go
+++ b/server.go
@@ -396,13 +396,16 @@ func (s *Io) handlerMessage(socket *Socket, message string) error {
 		special3 := -1
 		nextMess := message
 
+		tot := 0
+
 		for {
 			nextSpecial3 := strings.Index(string(nextMess), ",")
-			if nextSpecial3 == -1 || (special1 != -1 && nextSpecial3 > special1) || (special2 != -1 && nextSpecial3 > special2) {
+			if nextSpecial3 == -1 || (special1 != -1 && (tot+nextSpecial3) > special1) || (special2 != -1 && (tot+nextSpecial3) > special2) {
 				break
 			}
 			nextMess = nextMess[nextSpecial3+1:]
 			special3 = nextSpecial3
+			tot += nextSpecial3
 		}
 
 		if special3 != -1 {

--- a/server.go
+++ b/server.go
@@ -48,8 +48,7 @@ type Io struct {
 	onAuthentication func(params map[string]string) bool
 	onConnection     connectionEvent
 	close            chan interface{}
-
-	path string
+	path             string
 }
 
 type (
@@ -105,12 +104,8 @@ func New(fns ...optionFn) *Io {
 var upgrader = gWebsocket.Upgrader{}
 
 func (s *Io) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	log.Printf("[+] HTTP header: %+v", r.Header)
-	log.Printf("[+] HTTP query: %+v", r.URL.Query())
-
 	header := r.Header
 	if slices.Contains(header["Connection"], "Upgrade") && header.Get("Upgrade") == "websocket" {
-		log.Println("conection:upgrade")
 
 		upgrader.CheckOrigin = func(r *http.Request) bool { return true }
 		c, err := upgrader.Upgrade(w, r, nil)
@@ -368,7 +363,6 @@ func (s *Io) handlerMessage(socket *Socket, message string) error {
 	enginePacketType := string(message[0:1])
 	switch enginePacketType {
 	case engineio.MESSAGE.String():
-		// log.Println("[socket.io] string message")
 
 		mess := string(message)
 		packetType := string(message[1:2])
@@ -423,8 +417,6 @@ func (s *Io) handlerMessage(socket *Socket, message string) error {
 
 		switch packetType {
 		case socket_protocol.DISCONNECT.String():
-			// log.Println("[socket.io] disconnect message")
-
 			socket_nps, err := s.Of(namespace).sockets.get(socket.Id)
 			if err != nil {
 				return err
@@ -439,8 +431,6 @@ func (s *Io) handlerMessage(socket *Socket, message string) error {
 				})
 			}
 		case socket_protocol.CONNECT.String():
-			// log.Println("[socket.io] connect message")
-
 			socket_nps := socket
 			if namespace != "/" {
 				socketWithNamespace := Socket{
@@ -464,8 +454,6 @@ func (s *Io) handlerMessage(socket *Socket, message string) error {
 			}
 
 			if s.onAuthentication != nil {
-				// log.Printf("[socket.io] connect with auth")
-
 				dataJson := map[string]string{}
 				json.Unmarshal([]byte(rawpayload), &dataJson)
 				if !s.onAuthentication(dataJson) {
@@ -537,9 +525,11 @@ func (s *Io) handlerMessage(socket *Socket, message string) error {
 			// case socket_protocol.BINARY_ACK.String():
 		}
 	case engineio.PONG.String():
-		// println("[socket.io] client pong")
+		// log.Println("[socket.io] received pong")
+
 	default:
-		log.Println("[socket.io] un-handled message")
+		log.Printf("[socket.io] un-handled packet type: %q\n", enginePacketType)
 	}
+
 	return nil
 }

--- a/server.go
+++ b/server.go
@@ -10,6 +10,7 @@ import (
 	"reflect"
 	"slices"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/doquangtan/socketio/v4/client"
@@ -104,33 +105,54 @@ func New(fns ...optionFn) *Io {
 var upgrader = gWebsocket.Upgrader{}
 
 func (s *Io) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	log.Printf("[+] HTTP header: %+v", r.Header)
+	log.Printf("[+] HTTP query: %+v", r.URL.Query())
+
 	header := r.Header
 	if slices.Contains(header["Connection"], "Upgrade") && header.Get("Upgrade") == "websocket" {
+		// if true {
+		log.Println("conection:upgrade")
+
 		upgrader.CheckOrigin = func(r *http.Request) bool { return true }
 		c, err := upgrader.Upgrade(w, r, nil)
-
 		if err != nil {
 			log.Print("Upgrade:", err)
 			return
 		}
 		defer c.Close()
 
+		// var id string
+
 		if r.URL.Query()["sid"] != nil {
+			log.Print("sid presented ! ")
+
 			return
+			// Still allows it ?
 		}
+		// log.Println("SID:", id)
 
 		socket := Socket{
 			Id:  s.randomUUID(),
 			Nps: "/",
 			Conn: &Conn{
-				http: c,
+				http:       c,
+				reqHeaders: r.Header.Clone(),
+				reqQuery:   cloneValues(r.URL.Query()),
+				data:       &atomic.Pointer[any]{},
 			},
+
 			listeners: listeners{
 				list: make(map[string][]eventCallback),
 			},
 			pingTime: s.pingInterval,
 		}
-		defer socket.disconnect()
+
+		defer func() {
+			log.Printf("socket %q closed", socket.Id)
+
+			socket.disconnect()
+		}()
+
 		socket.dispose = append(socket.dispose, func() {
 			s.sockets.delete(socket.Id)
 		})

--- a/server.go
+++ b/server.go
@@ -47,9 +47,30 @@ type Io struct {
 	onAuthentication func(params map[string]string) bool
 	onConnection     connectionEvent
 	close            chan interface{}
+
+	path string
 }
 
-func New() *Io {
+type (
+	option struct {
+		path string
+	}
+	optionFn func(*option)
+)
+
+func SetPath(path string) optionFn { return func(opt *option) { opt.path = path } }
+
+func New(fns ...optionFn) *Io {
+	// Load sensible default value.
+	opt := option{
+		path: "/socket.io/",
+	}
+
+	// Overload them with user's provided ones.
+	for _, fn := range fns {
+		fn(&opt)
+	}
+
 	pingInterval := time.Duration(25000 * time.Millisecond)
 	pingTimeout := time.Duration(25000 * time.Millisecond)
 	maxPayload := 1000000
@@ -68,6 +89,7 @@ func New() *Io {
 		pingInterval: pingInterval,
 		pingTimeout:  pingTimeout,
 		maxPayload:   maxPayload,
+		path:         opt.path,
 	}
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	go io.read(ctx)
@@ -122,24 +144,36 @@ func (s *Io) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			Upgrades:     []string{"websocket"},
 		}.ToJson())
 
+		log.Printf("headers %q: %+v", socket.Id, socket.Conn.reqHeaders)
+		log.Printf("query %q: %+v", socket.Id, socket.Conn.reqQuery)
+
 		for {
 			messageType, message, err := c.ReadMessage()
 			if err != nil {
+				log.Printf("got error: %v\n", err)
 				break
 			}
 
 			if messageType == websocket.TextMessage {
 				err := s.handlerMessage(&socket, string(message))
 				if err != nil {
+					log.Printf("got error: %v\n", err)
+
 					return
 				}
 			}
 		}
-	} else if strings.HasPrefix(r.URL.Path, "/socket.io/") {
+	} else if strings.HasPrefix(r.URL.Path, s.path) {
+
+		log.Println("conection:path match")
+
 		clientDistFs, _ := fs.Sub(staticFS, "client-dist")
-		fs := http.StripPrefix("/socket.io/", http.FileServer(http.FS(clientDistFs)))
+		fs := http.StripPrefix(s.path, http.FileServer(http.FS(clientDistFs)))
 		fs.ServeHTTP(w, r)
 	} else {
+
+		log.Printf("conection:not found: got [%q] want [%q]", r.URL.Path, s.path)
+
 		http.NotFound(w, r)
 	}
 }

--- a/server_test.go
+++ b/server_test.go
@@ -1,0 +1,35 @@
+package socketio
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestHandlerMessage(t *testing.T) {
+	s := Io{
+		namespaces: namespaces{
+			list: map[string]*Namespace{
+				"/": {Name: ""},
+			},
+		},
+	}
+
+	// NOTE: That one already passed before eef17c02d9676f5463453a5f167205cd4c4bbba1
+	err := s.handlerMessage(&Socket{
+		Id: "test", Nsp: "/",
+	}, `42/ssh,["resize",{"cols":123,"rows":41}]`)
+
+	t.Logf("%T %v", err, err)
+
+	require.ErrorIs(t, err, ErrorInvalidConnection)
+	// NOTE: That one would panic prior to eef17c02d9676f5463453a5f167205cd4c4bbba1
+	require.NotPanics(t, func() {
+		err := s.handlerMessage(&Socket{
+			Id: "test", Nsp: "/",
+		}, `42/logview,["resize",{"cols":124,"rows":34}]`)
+		require.ErrorIs(t, err, ErrorInvalidConnection,
+			"parsed content shouldn't cause an error",
+		)
+	}, "input content shouldn't cause a panics")
+}

--- a/socket.go
+++ b/socket.go
@@ -3,7 +3,10 @@ package socketio
 import (
 	"errors"
 	"io"
+	"net/http"
+	"net/url"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/doquangtan/socketio/v4/engineio"
@@ -15,7 +18,28 @@ import (
 type Conn struct {
 	fasthttp *websocket.Conn
 	http     *gWebsocket.Conn
+
+	reqHeaders http.Header
+	reqQuery   url.Values
+
+	data *atomic.Pointer[any]
 }
+
+func (c *Conn) RequestHeaders() http.Header { return c.reqHeaders }
+func (c *Conn) RequestQuery() url.Values    { return c.reqQuery }
+
+func cloneValues(v url.Values) url.Values {
+	out := make(url.Values, len(v))
+	for k, vals := range v {
+		cp := make([]string, len(vals))
+		copy(cp, vals)
+		out[k] = cp
+	}
+	return out
+}
+
+func (c *Conn) SetData(data any) { c.data.Store(&data) }
+func (c *Conn) GetData() any     { return c.data.Load() }
 
 func (c *Conn) nextWriter(messageType int) (io.WriteCloser, error) {
 	if c.http != nil {

--- a/socket.go
+++ b/socket.go
@@ -3,7 +3,6 @@ package socketio
 import (
 	"errors"
 	"io"
-	"log"
 	"net/http"
 	"net/url"
 	"sync"
@@ -17,13 +16,11 @@ import (
 )
 
 type Conn struct {
-	fasthttp *websocket.Conn
-	http     *gWebsocket.Conn
-
+	fasthttp   *websocket.Conn
+	http       *gWebsocket.Conn
 	reqHeaders http.Header
 	reqQuery   url.Values
-
-	data *atomic.Pointer[any]
+	data       *atomic.Pointer[any]
 }
 
 func (c *Conn) RequestHeaders() http.Header { return c.reqHeaders }
@@ -136,8 +133,6 @@ func (s *Socket) Rooms() []string {
 }
 
 func (s *Socket) disconnect() {
-	log.Printf("[socket.io] closing socket %q", s.Id)
-
 	s.Conn.close()
 	s.Conn = nil
 	// s.rooms = []string{}

--- a/socket.go
+++ b/socket.go
@@ -3,6 +3,7 @@ package socketio
 import (
 	"errors"
 	"io"
+	"log"
 	"net/http"
 	"net/url"
 	"sync"
@@ -73,8 +74,9 @@ func (c *Conn) close() error {
 
 type Socket struct {
 	sync.RWMutex
+
 	Id        string
-	Nps       string
+	Nsp       string
 	Conn      *Conn
 	rooms     roomNames
 	listeners listeners
@@ -134,6 +136,8 @@ func (s *Socket) Rooms() []string {
 }
 
 func (s *Socket) disconnect() {
+	log.Printf("[socket.io] closing socket %q", s.Id)
+
 	s.Conn.close()
 	s.Conn = nil
 	// s.rooms = []string{}
@@ -163,9 +167,10 @@ func (s *Socket) writer(t socket_protocol.PacketType, arg ...interface{}) error 
 		return err
 	}
 	nps := ""
-	if s.Nps != "/" {
-		nps = s.Nps + ","
+	if s.Nsp != "/" {
+		nps = s.Nsp + ","
 	}
+
 	if t == socket_protocol.ACK {
 		agrs := append([]interface{}{}, arg[0].([]interface{})[1:])
 		socket_protocol.WriteToWithAck(w, t, nps, arg[0].([]interface{})[0].(string), agrs...)


### PR DESCRIPTION
- the request' header can now be access via `Conn.RequestHeaders()` (thread safe)
- the request' query can now be access via `Conn.RequestQuery()` (thread safe) 
- one may persist & access arbitrary data to the connection by using the `Conn.SetData` & `Conn.GetData` methods (see atomic.Pointer for hint about the whys) 
- the server' root URL can now be parametrized (was hard-coded to `/socket.io/`) (only std' http.Server ATM) 