### PR TITLE
Replace sync.RWMutex with async.PriorityLock for heartbeat write prio…

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/doquangtan/socketio/v4
 
-go 1.22.2
+go 1.23.0
 
 require (
 	github.com/gin-contrib/static v1.1.3
@@ -35,6 +35,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.3 // indirect
+	github.com/reugn/async v0.10.0 // indirect
 	github.com/rivo/uniseg v0.2.0 // indirect
 	github.com/savsgio/gotils v0.0.0-20230208104028-c358bd845dee // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-github.com/andybalholm/brotli v1.0.5 h1:8uQZIdzKmjc/iuPu7O2ioW48L81FgatrcpfFmiq/cCs=
-github.com/andybalholm/brotli v1.0.5/go.mod h1:fO7iG3H7G2nSZ7m0zPUDn85XEX2GTukHGRSepvi9Eig=
 github.com/andybalholm/brotli v1.1.0 h1:eLKJA0d02Lf0mVpIDgYnqXcUn0GqVmEFny3VuID1U3M=
 github.com/andybalholm/brotli v1.1.0/go.mod h1:sms7XGricyQI9K10gOSf56VKKWS4oLer58Q+mhRPtnY=
 github.com/bytedance/sonic v1.12.6 h1:/isNmCUF2x3Sh8RAp/4mh4ZGkcFAX/hLrzrK3AvpRzk=
@@ -35,8 +33,6 @@ github.com/go-playground/validator/v10 v10.23.0 h1:/PwmTwZhS0dPkav3cdK9kV1FsAmrL
 github.com/go-playground/validator/v10 v10.23.0/go.mod h1:dbuPbCMFw/DrkbEynArYaCwl3amGuJotoKCe95atGMM=
 github.com/goccy/go-json v0.10.4 h1:JSwxQzIqKfmFX1swYPpUThQZp/Ka4wzJdK0LWVytLPM=
 github.com/goccy/go-json v0.10.4/go.mod h1:oq7eo15ShAhp70Anwd5lgX2pLfOS3QCiwU/PULtXL6M=
-github.com/gofiber/fiber/v2 v2.52.5 h1:tWoP1MJQjGEe4GB5TUGOi7P2E0ZMMRx5ZTG4rT+yGMo=
-github.com/gofiber/fiber/v2 v2.52.5/go.mod h1:KEOE+cXMhXG0zHc9d8+E38hoX+ZN7bhOtgeF2oT6jrQ=
 github.com/gofiber/fiber/v2 v2.52.9 h1:YjKl5DOiyP3j0mO61u3NTmK7or8GzzWzCFzkboyP5cw=
 github.com/gofiber/fiber/v2 v2.52.9/go.mod h1:YEcBbO/FB+5M1IZNBP9FO3J9281zgPAreiI1oqg8nDw=
 github.com/gofiber/websocket/v2 v2.2.1 h1:C9cjxvloojayOp9AovmpQrk8VqvVnT8Oao3+IUygH7w=
@@ -50,8 +46,6 @@ github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aN
 github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
-github.com/klauspost/compress v1.17.0 h1:Rnbp4K9EjcDuVuHtd0dgA4qNuv9yKDYKK1ulpJwgrqM=
-github.com/klauspost/compress v1.17.0/go.mod h1:ntbaceVETuRiXiv4DpjP66DpAtAGkEQskQzEyD//IeE=
 github.com/klauspost/compress v1.17.9 h1:6KIumPrER1LHsvBVuDa0r5xaG0Es51mhhB9BQB2qeMA=
 github.com/klauspost/compress v1.17.9/go.mod h1:Di0epgTjJY877eYKx5yC51cX2A2Vl2ibi7bDH9ttBbw=
 github.com/klauspost/cpuid/v2 v2.0.9/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=
@@ -69,8 +63,6 @@ github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovk
 github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
-github.com/mattn/go-runewidth v0.0.15 h1:UNAjwbU9l54TA3KzvqLGxwWjHmMgBUVhBiTjelZgg3U=
-github.com/mattn/go-runewidth v0.0.15/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
 github.com/mattn/go-runewidth v0.0.16 h1:E5ScNMtiwvlvB5paMFdw9p4kSQzbXFikJ5SQO6TULQc=
 github.com/mattn/go-runewidth v0.0.16/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
@@ -82,6 +74,9 @@ github.com/pelletier/go-toml/v2 v2.2.3 h1:YmeHyLY8mFWbdkNWwpr+qIL2bEqT0o95WSdkNH
 github.com/pelletier/go-toml/v2 v2.2.3/go.mod h1:MfCQTFTvCcUyyvvwm1+G6H/jORL20Xlb6rzQu9GuUkc=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/reugn/async v0.9.0/go.mod h1:DeWMb1afOLRJjetJq+gVVII9jD3njyndoLbfpj9pr0M=
+github.com/reugn/async v0.10.0 h1:TRccMRb9HClRU0/st3DbhvPWzeHHjC0q2cRwNy9EHYg=
+github.com/reugn/async v0.10.0/go.mod h1:fNLcyRrqVzZ/C/TKzppyIKQxZDLLuRioaDlrjvE9KOk=
 github.com/rivo/uniseg v0.2.0 h1:S1pD9weZBuJdFmowNwbpi7BJ8TNftyUImj/0WQi72jY=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rogpeppe/go-internal v1.8.0 h1:FCbCCtXNOY3UtUuHUYaghJg4y7Fd14rXifAYUAtL9R8=

--- a/server.go
+++ b/server.go
@@ -16,6 +16,7 @@ import (
 	"github.com/doquangtan/socketio/v4/client"
 	"github.com/doquangtan/socketio/v4/engineio"
 	"github.com/doquangtan/socketio/v4/protocol"
+	"github.com/reugn/async"
 	"github.com/gofiber/fiber/v2"
 	"github.com/gofiber/fiber/v2/middleware/adaptor"
 	"github.com/gofiber/fiber/v2/middleware/filesystem"
@@ -121,6 +122,7 @@ func (s *Io) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			defer socket.disconnect()
 		} else {
 			socket = &Socket{
+				mu:  async.NewPriorityLock(2),
 				Id:  s.randomUUID(),
 				Nps: "/",
 				Conn: &Conn{
@@ -359,6 +361,7 @@ func (s *Io) handleWebsocket(ctx *fiber.Ctx) error {
 			defer socket.disconnect()
 		} else {
 			socket = &Socket{
+				mu:  async.NewPriorityLock(2),
 				Id:  s.randomUUID(),
 				Nps: "/",
 				Conn: &Conn{
@@ -404,6 +407,7 @@ func (s *Io) handleWebsocket(ctx *fiber.Ctx) error {
 
 func (s *Io) handleHandshake(w http.ResponseWriter, r *http.Request) {
 	socket := &Socket{
+		mu:  async.NewPriorityLock(2),
 		Id:  s.randomUUID(),
 		Nps: "/",
 		Conn: &Conn{
@@ -618,6 +622,7 @@ func (s *Io) handlerMessage(socket *Socket, message string) error {
 			socket_nps := socket
 			if namespace != "/" {
 				socketWithNamespace := Socket{
+					mu:   async.NewPriorityLock(2),
 					Id:   socket.Id,
 					Nps:  namespace,
 					Conn: socket.Conn,

--- a/socket.go
+++ b/socket.go
@@ -3,13 +3,13 @@ package socketio
 import (
 	"errors"
 	"io"
-	"sync"
 	"time"
 
 	"github.com/doquangtan/socketio/v4/engineio"
 	"github.com/doquangtan/socketio/v4/protocol"
 	"github.com/gofiber/websocket/v2"
 	gWebsocket "github.com/gorilla/websocket"
+	"github.com/reugn/async"
 )
 
 type Conn struct {
@@ -64,8 +64,13 @@ func (c *broadcastOperator) Emit(event string, agrs ...interface{}) error {
 	return nil
 }
 
+const (
+	prioHeartbeat = 2 // high priority for ping/pong/noop writes
+	prioData      = 1 // low priority for application data writes
+)
+
 type Socket struct {
-	sync.RWMutex
+	mu               *async.PriorityLock
 	Id               string
 	Nps              string
 	Conn             *Conn
@@ -157,8 +162,8 @@ func (s *Socket) disconnect() {
 }
 
 func (s *Socket) engineWrite(t engineio.PacketType, arg ...interface{}) error {
-	s.Lock()
-	defer s.Unlock()
+	s.mu.LockP(prioHeartbeat)
+	defer s.mu.Unlock()
 	w, err := s.Conn.nextWriter(websocket.TextMessage)
 	if err != nil {
 		return err
@@ -168,8 +173,8 @@ func (s *Socket) engineWrite(t engineio.PacketType, arg ...interface{}) error {
 }
 
 func (s *Socket) writer(t protocol.PacketType, arg ...interface{}) error {
-	s.Lock()
-	defer s.Unlock()
+	s.mu.LockP(prioData)
+	defer s.mu.Unlock()
 	w, err := s.Conn.nextWriter(websocket.TextMessage)
 	if err != nil {
 		return err


### PR DESCRIPTION
…rity

- Socket write lock replaced with PriorityLock to prevent heartbeat ping/pong writes from being starved under high data volume
- engineWrite (ping/pong/noop) uses LockP(prioHeartbeat=2) high priority
- writer (event/ack/connect) uses LockP(prioData=1) low priority
- Dependency: github.com/reugn/async v0.10.0